### PR TITLE
Utilisation d'un fork de la dépendence sleep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt": ">=0.4.0"
   },
   "devDependencies": {
-    "sleep": "https://github.com/kronos-pbrideau/node-sleep.git",
+    "sleep": "git+https://github.com/kronos-pbrideau/node-sleep.git",
     "grunt": "~0.4.5",
     "grunt-git": "~0.2.14",
     "grunt-bump": "0.0.15",
@@ -36,7 +36,7 @@
     "grunt-git": "~0.2.14",
     "grunt-release": "^0.7.0",
     "load-grunt-tasks": "^0.4.0",
-    "sleep": "https://github.com/kronos-pbrideau/node-sleep.git",
+    "sleep": "git+https://github.com/kronos-pbrideau/node-sleep.git",
     "sync-exec": "^0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt": ">=0.4.0"
   },
   "devDependencies": {
-    "sleep": "^2.0.0",
+    "sleep": "git://github.com/kronos-pbrideau/node-sleep.git",
     "grunt": "~0.4.5",
     "grunt-git": "~0.2.14",
     "grunt-bump": "0.0.15",
@@ -36,7 +36,7 @@
     "grunt-git": "~0.2.14",
     "grunt-release": "^0.7.0",
     "load-grunt-tasks": "^0.4.0",
-    "sleep": "^2.0.0",
+    "sleep": "git://github.com/kronos-pbrideau/node-sleep.git",
     "sync-exec": "^0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt": ">=0.4.0"
   },
   "devDependencies": {
-    "sleep": "git://github.com/kronos-pbrideau/node-sleep.git",
+    "sleep": "https://github.com/kronos-pbrideau/node-sleep.git",
     "grunt": "~0.4.5",
     "grunt-git": "~0.2.14",
     "grunt-bump": "0.0.15",
@@ -36,7 +36,7 @@
     "grunt-git": "~0.2.14",
     "grunt-release": "^0.7.0",
     "load-grunt-tasks": "^0.4.0",
-    "sleep": "git://github.com/kronos-pbrideau/node-sleep.git",
+    "sleep": "https://github.com/kronos-pbrideau/node-sleep.git",
     "sync-exec": "^0.5.0"
   }
 }


### PR DESCRIPTION
Suite à une mise à jour de nan, il n'est plus possible de déployer nos applications.
Le fork de sleep force l'utilisation de la version précédente de nan.